### PR TITLE
ERROR has different meanings

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -109,7 +109,7 @@ HM_IGNORE_DISCOVERY_NODE_EXCEPTIONS = {
 HM_ATTRIBUTE_SUPPORT = {
     'LOWBAT': ['battery', {0: 'High', 1: 'Low'}],
     'LOW_BAT': ['battery', {0: 'High', 1: 'Low'}],
-    'ERROR': ['sabotage', {0: 'No', 1: 'Yes'}],
+    'ERROR': ['error', {0: 'No'}],
     'ERROR_SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],
     'SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],
     # The following line is depricated and replaced by individual attributes


### PR DESCRIPTION
## Description:
ERROR has different meanings depending on the device. It is not only for sabotage errors but also for eg. LOWBAT on some devices. The numeric value will indicate the error details.

This change has no implication on the documentation because no attributes are detailed there.

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x] There is no commented out code in this PR.

